### PR TITLE
remove class on row header

### DIFF
--- a/packages/mdc-data-table/addon/components/mdc-data-table-header-row.js
+++ b/packages/mdc-data-table/addon/components/mdc-data-table-header-row.js
@@ -5,6 +5,4 @@ export default Component.extend({
   layout,
 
   tagName: 'thead',
-
-  classNames: 'mdc-data-table__header-row'
 });


### PR DESCRIPTION
The official docs doesn't have a class in the `thead` element: https://material.io/develop/web/components/data-tables/

```
<thead>
      <tr class="mdc-data-table__header-row">
         ...
      </tr>
    </thead>
```