### PR TITLE
Fix mdc-typography compatibility with rootelement

### DIFF
--- a/packages/mdc-typography/addon/instance-initializers/typography.js
+++ b/packages/mdc-typography/addon/instance-initializers/typography.js
@@ -16,7 +16,7 @@ export function initialize (app) {
   const { disabled = false} = config;
 
   if (!disabled) {
-    const rootElement = typeOf(app.rootElement) === 'string' ? document.querySelector (app.rootElement) : app.rootElement;
+    const rootElement = typeOf (app.rootElement) === 'string' ? document.querySelector (app.rootElement) : app.rootElement;
 
     if (isPresent (rootElement)) {
       rootElement.classList.add ('mdc-typography');

--- a/packages/mdc-typography/addon/instance-initializers/typography.js
+++ b/packages/mdc-typography/addon/instance-initializers/typography.js
@@ -1,5 +1,5 @@
 import { getWithDefault } from '@ember/object';
-import { isNone, isPresent } from '@ember/utils';
+import { isNone, isPresent, typeOf } from '@ember/utils';
 
 export function initialize (app) {
   // Make sure the window and document element exists. If neither exists, then
@@ -16,7 +16,7 @@ export function initialize (app) {
   const { disabled = false} = config;
 
   if (!disabled) {
-    const rootElement = document.querySelector (app.rootElement);
+    const rootElement = typeOf(app.rootElement) === 'string' ? document.querySelector (app.rootElement) : app.rootElement;
 
     if (isPresent (rootElement)) {
       rootElement.classList.add ('mdc-typography');


### PR DESCRIPTION
This PR fixes `rootElement` inside the `instance-initializers/typography.js` based in the [ember doc](https://guides.emberjs.com/release/configuring-ember/embedding-applications/) which says "This property can be specified as either an element [...]"

I'm using this component with ember-cli-storybook and the adapter uses rootElement with an HTMLDivElement.