### PR TITLE
Remove rebase artifacts

### DIFF
--- a/packages/mdc-card/README.md
+++ b/packages/mdc-card/README.md
@@ -29,17 +29,16 @@ mdc-card
 
 ### Description
 
-<<<<<<< HEAD
-The `{{mdc-card}}` is a component that implements the 
+The `{{mdc-card}}` is a component that implements the
 [Material Design card component](https://github.com/material-components/material-components-web/tree/master/packages/mdc-card).
 
 ### Usage
 
 ```handlebars
 {{#mdc-card outlined=[true|false]}}
-  
+
   <!-- ... content ... -->
-  
+
 {{/mdc-card}}
 ```
 
@@ -50,7 +49,7 @@ The `{{mdc-card}}` is a component that implements the
 Adding Media to the Card
 ---------------------------
 
-Use the `{{mdc-card-media}}` component to add an optional media component to the card. The 
+Use the `{{mdc-card-media}}` component to add an optional media component to the card. The
 `{{mdc-card-media}}` also contains the `{{mdc-card-media-content}}`, which is optional content
 displayed over the media, like a title.
 
@@ -59,9 +58,9 @@ displayed over the media, like a title.
   {{#mdc-card-media scale=["square"|"16-9"]}}
     {{#mdc-card-media-content}}Title{{/mdc-card-media-content}}
   {{/mdc-card-media}}
-  
+
   <!-- ... content ... -->
-  
+
 {{/mdc-card}}
 ```
 
@@ -72,14 +71,14 @@ displayed over the media, like a title.
 Adding Actions to the Card
 ----------------------------
 
-Actions typically appear at the bottom of the card. The actions can either be a button or 
-an icon button. Use the `{{mdc-card-actions}}` component, and its child components, to add 
+Actions typically appear at the bottom of the card. The actions can either be a button or
+an icon button. Use the `{{mdc-card-actions}}` component, and its child components, to add
 actions to a `{{mdc-card}}` component.
 
 ```handlebars
 {{#mdc-card}}
   <!-- ... content ... -->
-  
+
   {{#mdc-card-actions}}
     {{#mdc-card-action-buttons}}
       {{#mdc-card-action-button}}Action 1{{/mdc-card-action-button}}
@@ -93,10 +92,6 @@ actions to a `{{mdc-card}}` component.
   {{/mdc-card-actions}}
 {{/mdc-card}}
 ```
-=======
-See the [Contributing](CONTRIBUTING.md) guide for details.
-
->>>>>>> c5293e44... v3.3.0...v3.18.0
 
 ### Types of Actions
 

--- a/packages/mdc-card/config/ember-try.js
+++ b/packages/mdc-card/config/ember-try.js
@@ -2,22 +2,6 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-<<<<<<< HEAD
-module.exports = function() {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary')
-  ]).then((urls) => {
-    return {
-      scenarios: [
-        {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-=======
 module.exports = async function() {
   return {
     useYarn: true,
@@ -27,7 +11,6 @@ module.exports = async function() {
         npm: {
           devDependencies: {
             'ember-source': '~3.12.0'
->>>>>>> c5293e44... v3.3.0...v3.18.0
           }
         }
       },

--- a/packages/mdc-checkbox/config/ember-try.js
+++ b/packages/mdc-checkbox/config/ember-try.js
@@ -2,22 +2,6 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-<<<<<<< HEAD
-module.exports = function() {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary')
-  ]).then((urls) => {
-    return {
-      scenarios: [
-        {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-=======
 module.exports = async function() {
   return {
     useYarn: true,
@@ -27,7 +11,6 @@ module.exports = async function() {
         npm: {
           devDependencies: {
             'ember-source': '~3.12.0'
->>>>>>> 282df140... v3.3.0...v3.18.0
           }
         }
       },

--- a/packages/mdc-dom/config/ember-try.js
+++ b/packages/mdc-dom/config/ember-try.js
@@ -2,22 +2,6 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-<<<<<<< HEAD
-module.exports = function() {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary')
-  ]).then((urls) => {
-    return {
-      scenarios: [
-        {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-=======
 module.exports = async function() {
   return {
     useYarn: true,
@@ -27,7 +11,6 @@ module.exports = async function() {
         npm: {
           devDependencies: {
             'ember-source': '~3.12.0'
->>>>>>> 850aa2f3... v3.3.0...v3.18.0
           }
         }
       },

--- a/packages/mdc-fab/config/ember-try.js
+++ b/packages/mdc-fab/config/ember-try.js
@@ -2,22 +2,6 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-<<<<<<< HEAD
-module.exports = function() {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary')
-  ]).then((urls) => {
-    return {
-      scenarios: [
-        {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-=======
 module.exports = async function() {
   return {
     useYarn: true,
@@ -27,7 +11,6 @@ module.exports = async function() {
         npm: {
           devDependencies: {
             'ember-source': '~3.12.0'
->>>>>>> d8513d4e... v3.3.0...v3.18.0
           }
         }
       },

--- a/packages/mdc-floating-label/README.md
+++ b/packages/mdc-floating-label/README.md
@@ -22,7 +22,6 @@ Components
 
 This package contains the following top-level components.
 
-<<<<<<< HEAD
 * [`{{mdc-floating-label}}`](#mdc-floating-label)
 
 mdc-floating-label
@@ -38,10 +37,6 @@ with text field and select fields.
 ```handlebars
 {{#mdc-floating-label for="my-text-field-id"}}Hint text{{/mdc-floating-label}}
 ```
-=======
-See the [Contributing](CONTRIBUTING.md) guide for details.
-
->>>>>>> a902b3fe... v3.3.0...v3.18.0
 
 ### Attributes
 

--- a/packages/mdc-floating-label/config/ember-try.js
+++ b/packages/mdc-floating-label/config/ember-try.js
@@ -2,22 +2,6 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-<<<<<<< HEAD
-module.exports = function() {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary')
-  ]).then((urls) => {
-    return {
-      scenarios: [
-        {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-=======
 module.exports = async function() {
   return {
     useYarn: true,
@@ -27,7 +11,6 @@ module.exports = async function() {
         npm: {
           devDependencies: {
             'ember-source': '~3.12.0'
->>>>>>> a902b3fe... v3.3.0...v3.18.0
           }
         }
       },

--- a/packages/mdc-form-field/README.md
+++ b/packages/mdc-form-field/README.md
@@ -24,7 +24,6 @@ This package contains the following top-level components.
 
 * [`{{mdc-form-field}}`](#mdc-form-field)
 
-<<<<<<< HEAD
 This package contains the following mixins:
 
 * `FormFieldMixin`
@@ -44,10 +43,6 @@ upon interacting with the label.
   {{!-- add input here --}}
 {{/mdc-form-field}}
 ```
-=======
-See the [Contributing](CONTRIBUTING.md) guide for details.
-
->>>>>>> 15566a5b... v3.3.0...v3.18.0
 
 ### Attributes
 

--- a/packages/mdc-form-field/config/ember-try.js
+++ b/packages/mdc-form-field/config/ember-try.js
@@ -2,22 +2,6 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-<<<<<<< HEAD
-module.exports = function() {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary')
-  ]).then((urls) => {
-    return {
-      scenarios: [
-        {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-=======
 module.exports = async function() {
   return {
     useYarn: true,
@@ -27,7 +11,6 @@ module.exports = async function() {
         npm: {
           devDependencies: {
             'ember-source': '~3.12.0'
->>>>>>> 15566a5b... v3.3.0...v3.18.0
           }
         }
       },

--- a/packages/mdc-form/README.md
+++ b/packages/mdc-form/README.md
@@ -27,22 +27,21 @@ This package contains the following top-level components.
 * [`mdc-form`](#mdc-form)
 
 
-<<<<<<< HEAD
 mdc-form
 -------------
 
 ### Description
 
-A component version of the HTML `<form>` element. The `<MdcForm>` element allows 
-its parent to react to changes to the form, such as disabling the submit button when an 
+A component version of the HTML `<form>` element. The `<MdcForm>` element allows
+its parent to react to changes to the form, such as disabling the submit button when an
 input is invalid.
 
 The `<MdcForm>` element will gather all child input elements and listen to changes
 in its [validity state](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState).
-When the validity state of an input changes, the `<MdcForm>` component will call the 
+When the validity state of an input changes, the `<MdcForm>` component will call the
 `invalid` action. The `invalid` action can then mutate a variable that enables/disables
 the submit button. The `<MdcForm>` does not automatically enable/disable the submit button,
-if present, because the parent may have other criteria outside of the `<MdcForm>` knowledge 
+if present, because the parent may have other criteria outside of the `<MdcForm>` knowledge
 that determines if the submit button should be enabled/disabled.
 
 ### Usage
@@ -61,10 +60,8 @@ that determines if the submit button should be enabled/disabled.
 * **`validity`** - The action `f(state)` when the form's validity changes.
 
 ### Form Validity
-=======
-See the [Contributing](CONTRIBUTING.md) guide for details.
 
-The `<MdcForm>` element will yield the form's state (`{isValid, isInvalid}`). The 
+The `<MdcForm>` element will yield the form's state (`{isValid, isInvalid}`). The
 yielded values can then be used to modify elements inside the form. For example,
 it can be use to enable/disable a button.
 
@@ -72,7 +69,7 @@ it can be use to enable/disable a button.
 <MdcForm @validity={{this.validity}} submit={{this.submit}} reset={{this.reset}} as |form|>
 
   {{!-- add input components here --}}
-  
+
   <MdcButton @type="submit" @label="Submit" disabled={{form.isInvalid}} />
 </MdcForm>
 ```

--- a/packages/mdc-form/config/ember-try.js
+++ b/packages/mdc-form/config/ember-try.js
@@ -2,22 +2,6 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-<<<<<<< HEAD
-module.exports = function() {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary')
-  ]).then((urls) => {
-    return {
-      scenarios: [
-        {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-=======
 module.exports = async function() {
   return {
     useYarn: true,
@@ -27,7 +11,6 @@ module.exports = async function() {
         npm: {
           devDependencies: {
             'ember-source': '~3.12.0'
->>>>>>> d2006618... v3.3.0...v3.18.0
           }
         }
       },

--- a/packages/mdc-layout-grid/config/ember-try.js
+++ b/packages/mdc-layout-grid/config/ember-try.js
@@ -2,22 +2,6 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-<<<<<<< HEAD
-module.exports = function() {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary')
-  ]).then((urls) => {
-    return {
-      scenarios: [
-        {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-=======
 module.exports = async function() {
   return {
     useYarn: true,
@@ -27,7 +11,6 @@ module.exports = async function() {
         npm: {
           devDependencies: {
             'ember-source': '~3.12.0'
->>>>>>> 6d026038... v3.3.0...v3.18.0
           }
         }
       },

--- a/packages/mdc-linear-progress/config/ember-try.js
+++ b/packages/mdc-linear-progress/config/ember-try.js
@@ -1,12 +1,3 @@
-<<<<<<< HEAD
-module.exports = {
-  scenarios: [
-    {
-      name: 'ember-lts-2.12',
-      npm: {
-        devDependencies: {
-          'ember-source': '~2.12.0'
-=======
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
@@ -21,7 +12,6 @@ module.exports = async function() {
           devDependencies: {
             'ember-source': '~3.12.0'
           }
->>>>>>> a8eae090... v2.18.2...v3.18.0
         }
       },
       {

--- a/packages/mdc-rtl/config/ember-try.js
+++ b/packages/mdc-rtl/config/ember-try.js
@@ -2,22 +2,6 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-<<<<<<< HEAD
-module.exports = function() {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary')
-  ]).then((urls) => {
-    return {
-      scenarios: [
-        {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-=======
 module.exports = async function() {
   return {
     useYarn: true,
@@ -27,7 +11,6 @@ module.exports = async function() {
         npm: {
           devDependencies: {
             'ember-source': '~3.12.0'
->>>>>>> 8d77fb15... v3.3.0...v3.18.0
           }
         }
       },

--- a/packages/mdc-switch/README.md
+++ b/packages/mdc-switch/README.md
@@ -16,30 +16,8 @@ Installation
 ------------
 
     ember install ember-cli-mdc-switch
-    
+
 Example Code
 ---------------
 
-Please see example code in `tests/dummy/app/templates` while we work on documenting how to 
-use the components in this add-on.
-
-<<<<<<< HEAD
-``
-=======
-Usage
-------------------------------------------------------------------------------
-
-[Longer description of how to use the addon in apps.]
-
-
-Contributing
-------------------------------------------------------------------------------
-
-See the [Contributing](CONTRIBUTING.md) guide for details.
-
-
-License
-------------------------------------------------------------------------------
-
-This project is licensed under the [MIT License](LICENSE.md).
->>>>>>> 23dbd9c0... v3.3.0...v3.18.0
+Please see example code in `tests/dummy/app/templates` while we work on documenting how to use the components in this add-on.

--- a/packages/mdc-switch/config/ember-try.js
+++ b/packages/mdc-switch/config/ember-try.js
@@ -2,22 +2,6 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-<<<<<<< HEAD
-module.exports = function() {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary')
-  ]).then((urls) => {
-    return {
-      scenarios: [
-        {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-=======
 module.exports = async function() {
   return {
     useYarn: true,
@@ -27,7 +11,6 @@ module.exports = async function() {
         npm: {
           devDependencies: {
             'ember-source': '~3.12.0'
->>>>>>> 23dbd9c0... v3.3.0...v3.18.0
           }
         }
       },

--- a/packages/mdc-typography/config/ember-try.js
+++ b/packages/mdc-typography/config/ember-try.js
@@ -2,7 +2,6 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-<<<<<<< HEAD
 module.exports = async function() {
   return {
     useYarn: true,


### PR DESCRIPTION
The PR removes rebase artifacts from README.md and ember-try.js files. This allows you to run ember-try e.g.

```js
cd packages/mdc-checkbox
npm install
npm run test:ember-compatibility
```
Unrelated to this PR getting test failures.